### PR TITLE
Simplify patient web auth endpoints

### DIFF
--- a/oncolife_monorepo/apps/patient-web/src/config/api.ts
+++ b/oncolife_monorepo/apps/patient-web/src/config/api.ts
@@ -2,10 +2,10 @@ export const API_CONFIG = {
   BASE_URL: '/api',
   ENDPOINTS: {
     AUTH: {
-      LOGIN: '/auth/login',
-      SIGNUP: '/auth/signup',
-      COMPLETE_NEW_PASSWORD: '/auth/complete-new-password',
-      LOGOUT: '/auth/logout'
+      LOGIN: '/login',
+      SIGNUP: '/signup',
+      COMPLETE_NEW_PASSWORD: '/complete-new-password',
+      LOGOUT: '/logout'
     },
     PROFILE: '/profile',
     NOTES: '/notes',


### PR DESCRIPTION
## Summary
- simplify patient auth endpoints to drop `/auth` prefix

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint --workspace=@oncolife/patient-web` *(fails: ESLint found 33 problems)*

------
https://chatgpt.com/codex/tasks/task_e_68945fafae9483319388717352e38a3f